### PR TITLE
Wrong method name for the except example.

### DIFF
--- a/eloquent-collections.md
+++ b/eloquent-collections.md
@@ -57,7 +57,7 @@ The `diff` method returns all of the models that are not present in the given co
 
 The `except` method returns all of the models that do not have the given primary keys:
 
-    $users = $users->only([1, 2, 3]);
+    $users = $users->except([1, 2, 3]);
 
 #### `find($key)` {#collection-method .first-collection-method}
 


### PR DESCRIPTION
The `except` example was using `only` instead of `except`.